### PR TITLE
Fix erronous code for php 7.2

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -4,8 +4,8 @@
 
 
 
-	define_safe(MUF_NAME, 'Field: Multilingual Upload');
-	define_safe(MUF_GROUP, 'multilingual_upload_field');
+	define_safe('MUF_NAME', 'Field: Multilingual Upload');
+	define_safe('MUF_GROUP', 'multilingual_upload_field');
 
 
 


### PR DESCRIPTION
The constants MUF_NAME and MUF_GROUP does not exists. In  php 7.2, use of inexistant constant gives an error.